### PR TITLE
feat: add IIFE standalone build for PHP/script-tag usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ logs
 .vscode/
 *.pem
 
+# Local test files
+test-standalone.html
+
 # Temporary files
 *.swp
 *.swo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skuse-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A modern, beautiful OpenAPI documentation viewer — fully compatible with OpenAPI 3.0 and 3.1",
   "keywords": ["openapi", "swagger", "api", "documentation", "react", "ui"],
   "license": "MIT",
@@ -19,14 +19,16 @@
       "require": "./dist/skuse-ui.cjs.js",
       "types": "./dist/index.d.ts"
     },
-    "./style.css": "./dist/style.css"
+    "./style.css": "./dist/style.css",
+    "./standalone.js": "./dist/skuse-ui.iife.js"
   },
   "files": [
     "dist"
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build --mode lib",
+    "build": "tsc -b && vite build --mode lib && vite build --mode standalone",
+    "build:standalone": "vite build --mode standalone",
     "build:app": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/src/SkuseDocumentation.tsx
+++ b/src/SkuseDocumentation.tsx
@@ -17,6 +17,8 @@ export interface SkuseDocumentationProps {
     openApiUrl: string;
     /** Default: 'system' */
     theme?: 'light' | 'dark' | 'system';
+    /** Default: 'browser'. Use 'hash' for standalone/embedded usage (no server SPA config needed) */
+    routerMode?: 'browser' | 'hash';
 }
 
 // Internal layout — rendered inside the router context
@@ -100,8 +102,9 @@ export const DocumentationShell: React.FC<{ openApiUrl: string }> = ({ openApiUr
 export const SkuseDocumentation: React.FC<SkuseDocumentationProps> = ({
     openApiUrl,
     theme = 'system',
+    routerMode = 'browser',
 }) => {
-    const router = useMemo(() => createAppRouter(openApiUrl), [openApiUrl]);
+    const router = useMemo(() => createAppRouter(openApiUrl, routerMode), [openApiUrl, routerMode]);
 
     return (
         <ThemeProvider defaultTheme={theme} storageKey="skuse-ui-theme">

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,7 +1,8 @@
 import {
     Route,
     RootRoute,
-    Router
+    Router,
+    createHashHistory,
 } from '@tanstack/react-router';
 import Information from '@/components/openapi/Information';
 import { DocumentationShell } from "@/SkuseDocumentation";
@@ -9,7 +10,7 @@ import EndpointDetails from "@/components/openapi/Endpoint/EndpointDetails";
 import Models from "@/components/openapi/Models";
 import WebhookDetails from "@/components/openapi/WebhookDetails";
 
-export function createAppRouter(openApiUrl: string) {
+export function createAppRouter(openApiUrl: string, routerMode: 'browser' | 'hash' = 'browser') {
     const rootRoute = new RootRoute({
         component: () => <DocumentationShell openApiUrl={openApiUrl} />
     });
@@ -40,5 +41,8 @@ export function createAppRouter(openApiUrl: string) {
 
     const routeTree = rootRoute.addChildren([indexRoute, endpointRoute, modelsRoute, webhookRoute]);
 
-    return new Router({ routeTree });
+    return new Router({
+        routeTree,
+        ...(routerMode === 'hash' ? { history: createHashHistory() } : {}),
+    });
 }

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { SkuseDocumentation, SkuseDocumentationProps } from './SkuseDocumentation';
+import './index.css';
+
+export function mount(selector: string, options: SkuseDocumentationProps): void {
+    const el = document.querySelector(selector);
+    if (!el) {
+        console.error(`[SkuseUI] Element not found: ${selector}`);
+        return;
+    }
+    ReactDOM.createRoot(el as HTMLElement).render(
+        React.createElement(SkuseDocumentation, { ...options, routerMode: 'hash' })
+    );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,24 @@ export default defineConfig(({ mode }) => ({
         },
       },
     },
+  } : mode === 'standalone' ? {
+    lib: {
+      entry: resolve(__dirname, 'src/standalone.ts'),
+      name: 'SkuseUI',
+      formats: ['iife'],
+      fileName: () => 'skuse-ui.iife.js',
+    },
+    outDir: 'dist',
+    emptyOutDir: false,
+    cssCodeSplit: false,
+    rollupOptions: {
+      output: {
+        assetFileNames: (info) => {
+          if (info.names?.some(n => n.endsWith('.css'))) return 'style.css';
+          return info.names?.[0] ?? 'asset';
+        },
+      },
+    },
   } : {
     outDir: 'dist-app',
   },


### PR DESCRIPTION
Adds a new `vite build --mode standalone` target that bundles React internally and exposes `window.SkuseUI.mount(selector, options)`. Uses hash history by default to avoid server-side SPA routing requirements. Bumps to 0.1.2.