### PR TITLE
fix: resolve relative openApiUrl against window.location before URL c…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skuse-ui",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A modern, beautiful OpenAPI documentation viewer — fully compatible with OpenAPI 3.0 and 3.1",
   "keywords": ["openapi", "swagger", "api", "documentation", "react", "ui"],
   "license": "MIT",

--- a/src/hooks/useSpec.ts
+++ b/src/hooks/useSpec.ts
@@ -62,7 +62,8 @@ export function useSpec({ openApiUrl, updateTitle = false }: { openApiUrl: strin
                         : 'API Docs - Skuse UI';
                 }
 
-                const initialUrl = calculateInitialUrl(resolvedSpec, openApiUrl);
+                const absoluteSpecUrl = new URL(openApiUrl, window.location.href).href;
+                const initialUrl = calculateInitialUrl(resolvedSpec, absoluteSpecUrl);
                 setComputedUrl(initialUrl);
 
                 if (resolvedSpec.servers?.[0]?.variables) {


### PR DESCRIPTION
Passing a relative URL to new URL(base) threw "Invalid base URL" when the standalone IIFE was used in a PHP context where only a path is provided.