### PR TITLE
fix: skip CORS proxy for same-origin and private/localhost addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skuse-ui",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A modern, beautiful OpenAPI documentation viewer — fully compatible with OpenAPI 3.0 and 3.1",
   "keywords": ["openapi", "swagger", "api", "documentation", "react", "ui"],
   "license": "MIT",

--- a/src/hooks/usePlayground.ts
+++ b/src/hooks/usePlayground.ts
@@ -248,7 +248,9 @@ export function usePlayground({ method, path, parameters, security, requestBody 
             if (hasBody) headers['Content-Type'] = contentType;
 
             const finalUrl = url.toString();
-            const fetchUrl = `https://proxy.scalar.com?scalar_url=${encodeURIComponent(finalUrl)}`;
+            const isSameOrigin = url.origin === window.location.origin;
+            const isPrivate = ['localhost', '127.0.0.1', '::1'].includes(url.hostname) || url.hostname.startsWith('192.168.') || url.hostname.startsWith('10.') || url.hostname.endsWith('.local');
+            const fetchUrl = (isSameOrigin || isPrivate) ? finalUrl : `https://proxy.scalar.com?scalar_url=${encodeURIComponent(finalUrl)}`;
             const start = performance.now();
             const response = await fetch(fetchUrl, {
                 method,


### PR DESCRIPTION
proxy.scalar.com blocks private addresses by design. Direct fetch is correct when the API is on the same origin or on a local network address.