### PR TITLE
fix: skip CORS proxy for same-origin and private/localhost addresses, bump 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skuse-ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A modern, beautiful OpenAPI documentation viewer — fully compatible with OpenAPI 3.0 and 3.1",
   "keywords": ["openapi", "swagger", "api", "documentation", "react", "ui"],
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Skip \`proxy.scalar.com\` when the target URL is same-origin or a private/localhost address
- proxy.scalar.com blocks private addresses by design — direct fetch is correct in these cases
- Bumps to 0.1.5

## Test plan
- [x] Test playground on a localhost API (e.g. API Platform demo at \`https://localhost\`)
- [x] Verify cross-origin public APIs still go through the proxy

🤖 Generated with [Claude Code](https://claude.ai/claude-code)