### PR TITLE
fix: support multipart/form-data, pre-select first enum option, scope preferredContentType to endpoint

### DIFF
--- a/src/components/openapi/Endpoint/CodeExamples.tsx
+++ b/src/components/openapi/Endpoint/CodeExamples.tsx
@@ -16,7 +16,7 @@ interface CodeExamplesProps {
     path: string;
     requestBody?: string;
     hasRequestBody?: boolean;
-    defaultContentType?: string;
+    contentTypes?: string[];
     security?: Array<Record<string, string[]>>;
     exampleQueryParams?: Record<string, string>;
     exampleHeaderParams?: Array<{ key: string; value: string }>;
@@ -87,7 +87,7 @@ function resolveAuthHeaders(
 }
 
 const CodeExamples: React.FC<CodeExamplesProps> = ({
-    method, path, requestBody, hasRequestBody, defaultContentType,
+    method, path, requestBody, hasRequestBody, contentTypes,
     security, exampleQueryParams, exampleHeaderParams,
 }) => {
     const { computedUrl, credentials, spec, preferredContentType } = useOpenAPIContext();
@@ -112,7 +112,9 @@ const CodeExamples: React.FC<CodeExamplesProps> = ({
                     ? `${computedUrl}${path}?${new URLSearchParams(mergedQuery)}`
                     : `${computedUrl}${path}`;
 
-                const contentType = preferredContentType ?? defaultContentType ?? 'application/json';
+                const contentType = (preferredContentType && contentTypes?.includes(preferredContentType))
+                    ? preferredContentType
+                    : (contentTypes?.[0] ?? 'application/json');
                 const allHeaders: HeaderDef[] = [
                     ...(exampleHeaderParams ?? []),
                     ...authHeaders,
@@ -146,7 +148,7 @@ const CodeExamples: React.FC<CodeExamplesProps> = ({
         })();
 
         return () => { cancelled = true; };
-    }, [method, path, requestBody, hasRequestBody, selectedLang, computedUrl, credentials, security, spec, preferredContentType, exampleQueryParams, exampleHeaderParams, defaultContentType]);
+    }, [method, path, requestBody, hasRequestBody, selectedLang, computedUrl, credentials, security, spec, preferredContentType, exampleQueryParams, exampleHeaderParams, contentTypes]);
 
     return (
         <div className="space-y-4">

--- a/src/components/openapi/Endpoint/EndpointDetails.tsx
+++ b/src/components/openapi/Endpoint/EndpointDetails.tsx
@@ -232,6 +232,10 @@ const EndpointContent: React.FC<EndpointContentProps> = ({ operation }) => {
                                 setHeaderValues={playground.setHeaderValues}
                                 body={playground.body}
                                 setBody={playground.setBody}
+                                formFields={playground.formFields}
+                                setFormFields={playground.setFormFields}
+                                formFiles={playground.formFiles}
+                                setFormFiles={playground.setFormFiles}
                                 contentType={playground.contentType}
                                 setContentType={playground.setContentType}
                                 contentTypes={playground.contentTypes}
@@ -319,7 +323,7 @@ const EndpointContent: React.FC<EndpointContentProps> = ({ operation }) => {
                                 path={examplePath}
                                 requestBody={exampleBody}
                                 hasRequestBody={!!requestBody}
-                                defaultContentType={requestBody ? Object.keys(requestBody.content)[0] : undefined}
+                                contentTypes={requestBody ? Object.keys(requestBody.content) : undefined}
                                 security={operation.security}
                                 exampleQueryParams={exampleQueryParams}
                                 exampleHeaderParams={exampleHeaderParams}

--- a/src/components/openapi/Endpoint/PlaygroundForm.tsx
+++ b/src/components/openapi/Endpoint/PlaygroundForm.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { WrapText } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
-import { ParameterObject, RequestBodyObject } from '@/types/unified-openapi-types';
+import { ParameterObject, RequestBodyObject, SchemaObject } from '@/types/unified-openapi-types';
 import { getTypeColorClass } from './SchemaBadges';
 import { Switch } from '@/components/ui/switch';
+import { isFormType } from '@/hooks/usePlayground';
 
 const LOCATION_STYLES: Record<string, string> = {
     path: 'border-orange-200 dark:border-orange-800 text-orange-700 dark:text-orange-300 bg-orange-50 dark:bg-orange-950/40',
@@ -28,6 +29,10 @@ interface PlaygroundFormProps {
     setHeaderValues: SetRecord;
     body: string;
     setBody: (v: string) => void;
+    formFields: Record<string, string>;
+    setFormFields: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+    formFiles: Record<string, File>;
+    setFormFiles: React.Dispatch<React.SetStateAction<Record<string, File>>>;
     contentType: string;
     setContentType: (v: string) => void;
     contentTypes: string[];
@@ -92,6 +97,105 @@ const ParamRow: React.FC<{
     </div>
 );
 
+const FormFieldsEditor: React.FC<{
+    contentType: string;
+    requestBody: RequestBodyObject;
+    formFields: Record<string, string>;
+    setFormFields: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+    formFiles: Record<string, File>;
+    setFormFiles: React.Dispatch<React.SetStateAction<Record<string, File>>>;
+    validationErrors: string[];
+}> = ({ contentType, requestBody, formFields, setFormFields, formFiles, setFormFiles, validationErrors }) => {
+    const schema = requestBody.content[contentType]?.schema as SchemaObject | undefined;
+    const properties = schema?.properties ?? {};
+    const required = schema?.required ?? [];
+    const entries = Object.entries(properties);
+    const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+    if (entries.length === 0) {
+        return <p className="text-xs text-muted-foreground italic">No schema properties defined.</p>;
+    }
+
+    return (
+        <div className="space-y-3">
+            {entries.map(([name, prop]) => {
+                const isFile = prop.format === 'binary';
+                const isRequired = required.includes(name);
+                const isInvalid = validationErrors.includes(`form:${name}`);
+                return (
+                    <div key={name} className="space-y-1">
+                        <div className="flex items-center gap-1.5">
+                            <span className="font-mono text-xs font-medium">
+                                {name}{isRequired && <span className="text-red-500 ml-0.5">*</span>}
+                            </span>
+                            {prop.type && (
+                                <Badge variant="outline" className={`text-[10px] px-1.5 py-0 h-4 font-mono font-normal ${getTypeColorClass(String(prop.type))}`}>
+                                    {isFile ? 'file' : String(prop.type)}
+                                </Badge>
+                            )}
+                            {prop.format && !isFile && (
+                                <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4 font-mono font-normal text-muted-foreground">
+                                    {prop.format}
+                                </Badge>
+                            )}
+                        </div>
+                        {isFile ? (
+                            <div className="flex items-center gap-2">
+                                <input
+                                    ref={el => { fileInputRefs.current[name] = el; }}
+                                    type="file"
+                                    className="hidden"
+                                    onChange={e => {
+                                        const file = e.target.files?.[0];
+                                        if (file) setFormFiles(prev => ({ ...prev, [name]: file }));
+                                    }}
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => fileInputRefs.current[name]?.click()}
+                                    className={cn(
+                                        'h-7 px-3 text-xs font-mono rounded-md border border-input bg-background hover:bg-muted transition-colors',
+                                        isInvalid && 'border-red-400'
+                                    )}
+                                >
+                                    {formFiles[name] ? formFiles[name].name : 'Choose file…'}
+                                </button>
+                                {formFiles[name] && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setFormFiles(prev => { const n = { ...prev }; delete n[name]; return n; })}
+                                        className="text-xs text-muted-foreground hover:text-foreground"
+                                    >
+                                        ✕
+                                    </button>
+                                )}
+                            </div>
+                        ) : Array.isArray(prop.enum) && prop.enum.length > 0 ? (
+                            <Select value={formFields[name] ?? ''} onValueChange={v => setFormFields(prev => ({ ...prev, [name]: v }))}>
+                                <SelectTrigger className={cn('h-7 text-xs font-mono w-full', isInvalid && 'border-red-400 focus-visible:ring-red-400')}>
+                                    <SelectValue placeholder={prop.description ?? name} />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {(prop.enum as unknown[]).map(v => (
+                                        <SelectItem key={String(v)} value={String(v)} className="text-xs font-mono">{String(v)}</SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        ) : (
+                            <Input
+                                value={formFields[name] ?? ''}
+                                onChange={e => setFormFields(prev => ({ ...prev, [name]: e.target.value }))}
+                                placeholder={prop.description ?? name}
+                                className={cn('h-7 text-xs font-mono w-full', isInvalid && 'border-red-400 focus-visible:ring-red-400')}
+                            />
+                        )}
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
+
 const PlaygroundForm: React.FC<PlaygroundFormProps> = ({
     parameters,
     requestBody,
@@ -99,6 +203,8 @@ const PlaygroundForm: React.FC<PlaygroundFormProps> = ({
     queryValues, setQueryValues,
     headerValues, setHeaderValues,
     body, setBody,
+    formFields, setFormFields,
+    formFiles, setFormFiles,
     contentType, setContentType,
     contentTypes,
     validationErrors,
@@ -187,17 +293,29 @@ const PlaygroundForm: React.FC<PlaygroundFormProps> = ({
                         )}
                     </div>
 
-                    <textarea
-                        value={body}
-                        onChange={e => setBody(e.target.value)}
-                        rows={8}
-                        spellCheck={false}
-                        placeholder='{"key": "value"}'
-                        className={cn(
-                            'w-full text-xs font-mono rounded-md border border-input bg-background px-3 py-2 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y',
-                            validationErrors.includes('__body__') && 'border-red-400 focus-visible:ring-red-400'
-                        )}
-                    />
+                    {isFormType(contentType) ? (
+                        <FormFieldsEditor
+                            contentType={contentType}
+                            requestBody={requestBody!}
+                            formFields={formFields}
+                            setFormFields={setFormFields}
+                            formFiles={formFiles}
+                            setFormFiles={setFormFiles}
+                            validationErrors={validationErrors}
+                        />
+                    ) : (
+                        <textarea
+                            value={body}
+                            onChange={e => setBody(e.target.value)}
+                            rows={8}
+                            spellCheck={false}
+                            placeholder='{"key": "value"}'
+                            className={cn(
+                                'w-full text-xs font-mono rounded-md border border-input bg-background px-3 py-2 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y',
+                                validationErrors.includes('__body__') && 'border-red-400 focus-visible:ring-red-400'
+                            )}
+                        />
+                    )}
                 </div>
             )}
 

--- a/src/components/openapi/Endpoint/RequestBodyViewer.tsx
+++ b/src/components/openapi/Endpoint/RequestBodyViewer.tsx
@@ -11,6 +11,7 @@ import {
     SchemaObject,
     ExampleObject
 } from "@/types/unified-openapi-types";
+import { isFormType } from '@/hooks/usePlayground';
 import {
     Select,
     SelectContent,
@@ -141,7 +142,7 @@ const RequestBodyViewer: React.FC<RequestBodyViewerProps> = ({ requestBody, hide
                 </div>
             )}
 
-            {content && !hideExample && (
+            {content && !hideExample && !isFormType(activeContentType) && (
                 <div className="space-y-2">
                     <h4 className="text-sm font-medium text-foreground">Example</h4>
                     {content.examples && Object.keys(content.examples).length > 0 && (

--- a/src/hooks/usePlayground.ts
+++ b/src/hooks/usePlayground.ts
@@ -4,6 +4,25 @@ import { useOpenAPIContext } from '@/hooks/OpenAPIContext';
 import { ParameterObject, RequestBodyObject, SchemaObject } from '@/types/unified-openapi-types';
 import { generateExample } from '@/utils/openapi';
 
+export const isFormType = (ct: string) =>
+    ct === 'multipart/form-data' || ct === 'application/x-www-form-urlencoded';
+
+const getFormFields = (ct: string, requestBody?: RequestBodyObject): Record<string, string> => {
+    if (!requestBody || !isFormType(ct)) return {};
+    const schema = requestBody.content[ct]?.schema as SchemaObject | undefined;
+    if (!schema?.properties) return {};
+    return Object.fromEntries(
+        Object.entries(schema.properties)
+            .filter(([, prop]) => prop.format !== 'binary')
+            .map(([key, prop]) => [
+                key,
+                prop.default !== undefined
+                    ? String(prop.default)
+                    : (Array.isArray(prop.enum) && prop.enum.length > 0 ? String(prop.enum[0]) : ''),
+            ])
+    );
+};
+
 export interface PlaygroundResult {
     status: number;
     statusText: string;
@@ -25,7 +44,7 @@ interface UsePlaygroundOptions {
 const getDefaultParamValue = (p: ParameterObject): string => {
     const schema = p.schema as SchemaObject | undefined;
     if (schema?.default !== undefined) return String(schema.default);
-    if (Array.isArray(schema?.enum) && schema.enum.length === 1) return String(schema.enum[0]);
+    if (Array.isArray(schema?.enum) && schema.enum.length > 0) return String(schema.enum[0]);
     return '';
 };
 
@@ -81,9 +100,16 @@ export function usePlayground({ method, path, parameters, security, requestBody 
     }, [requestBody]);
 
     const [body, setBody] = useState<string>(() => getDefaultBody(contentTypes[0] ?? ''));
+    const [formFields, setFormFields] = useState<Record<string, string>>(() => getFormFields(contentType, requestBody));
+    const [formFiles, setFormFiles] = useState<Record<string, File>>({});
 
     useEffect(() => {
-        setBody(getDefaultBody(contentType));
+        if (isFormType(contentType)) {
+            setFormFields(getFormFields(contentType, requestBody));
+            setFormFiles({});
+        } else {
+            setBody(getDefaultBody(contentType));
+        }
     }, [contentType]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const [enabledParams, setEnabledParams] = useState<Record<string, boolean>>(() =>
@@ -105,6 +131,8 @@ export function usePlayground({ method, path, parameters, security, requestBody 
         setHeaderValues(Object.fromEntries(parameters.filter(p => p.in === 'header').map(p => [p.name, getDefaultParamValue(p)])));
         setEnabledParams(Object.fromEntries(parameters.map(p => [`${p.in}:${p.name}`, true])));
         setBody(getDefaultBody(contentType));
+        setFormFields(getFormFields(contentType, requestBody));
+        setFormFiles({});
         setResult(null);
         setError(null);
         setValidationErrors([]);
@@ -167,15 +195,33 @@ export function usePlayground({ method, path, parameters, security, requestBody 
             if (param && !isEnabled(param)) continue;
             if (val !== '') headers[key] = val;
         }
-        const hasBody = !!requestBody && method !== 'GET' && method !== 'HEAD' && body !== '';
-        if (hasBody) headers['Content-Type'] = contentType;
+        const hasBody = !!requestBody && method !== 'GET' && method !== 'HEAD';
+        if (hasBody && contentType === 'application/x-www-form-urlencoded') headers['Content-Type'] = contentType;
+        else if (hasBody && !isFormType(contentType) && body !== '') headers['Content-Type'] = contentType;
 
         const parts = [`curl -X ${method}`];
         for (const [k, v] of Object.entries(headers)) parts.push(`  -H "${k}: ${v}"`);
-        if (hasBody) parts.push(`  --data-raw '${body.replace(/'/g, "'\\''")}'`);
+        if (hasBody) {
+            if (contentType === 'multipart/form-data') {
+                for (const [k, v] of Object.entries(formFields)) {
+                    if (v !== '') parts.push(`  -F "${k}=${v}"`);
+                }
+                for (const [k, f] of Object.entries(formFiles)) {
+                    parts.push(`  -F "${k}=@${f.name}"`);
+                }
+            } else if (contentType === 'application/x-www-form-urlencoded') {
+                const encoded = Object.entries(formFields)
+                    .filter(([, v]) => v !== '')
+                    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+                    .join('&');
+                if (encoded) parts.push(`  --data '${encoded}'`);
+            } else if (body !== '') {
+                parts.push(`  --data-raw '${body.replace(/'/g, "'\\''")}'`);
+            }
+        }
         parts.push(`  "${url.toString()}"`);
         return parts.join(' \\\n');
-    }, [method, path, pathValues, queryValues, headerValues, body, contentType, computedUrl, security, credentials, requestBody, enabledParams]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [method, path, pathValues, queryValues, headerValues, body, contentType, computedUrl, security, credentials, requestBody, enabledParams, formFields, formFiles]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const send = useCallback(async () => {
         const missing: string[] = [];
@@ -186,7 +232,16 @@ export function usePlayground({ method, path, parameters, security, requestBody 
             if (p.in === 'query' && !queryValues[p.name]?.trim()) missing.push(`query:${p.name}`);
             if (p.in === 'header' && !headerValues[p.name]?.trim()) missing.push(`header:${p.name}`);
         }
-        if (requestBody?.required && !body.trim()) missing.push('__body__');
+        if (isFormType(contentType) && requestBody) {
+            const schema = requestBody.content[contentType]?.schema as SchemaObject | undefined;
+            for (const field of (schema?.required ?? [])) {
+                const prop = schema?.properties?.[field];
+                const isFile = prop?.format === 'binary';
+                if (isFile ? !formFiles[field] : !formFields[field]?.trim()) missing.push(`form:${field}`);
+            }
+        } else if (requestBody?.required && !body.trim()) {
+            missing.push('__body__');
+        }
         setValidationErrors(missing);
         if (missing.length > 0) {
             toast.error('Fill in required fields before sending.');
@@ -244,8 +299,30 @@ export function usePlayground({ method, path, parameters, security, requestBody 
                 if (val !== '') headers[key] = val;
             }
 
-            const hasBody = !!requestBody && method !== 'GET' && method !== 'HEAD' && body !== '';
-            if (hasBody) headers['Content-Type'] = contentType;
+            let fetchBody: BodyInit | undefined;
+            const hasBody = !!requestBody && method !== 'GET' && method !== 'HEAD';
+            if (hasBody) {
+                if (contentType === 'multipart/form-data') {
+                    const fd = new FormData();
+                    for (const [k, v] of Object.entries(formFields)) {
+                        if (v !== '') fd.append(k, v);
+                    }
+                    for (const [k, f] of Object.entries(formFiles)) {
+                        fd.append(k, f, f.name);
+                    }
+                    fetchBody = fd;
+                } else if (contentType === 'application/x-www-form-urlencoded') {
+                    const params = new URLSearchParams();
+                    for (const [k, v] of Object.entries(formFields)) {
+                        if (v !== '') params.set(k, v);
+                    }
+                    fetchBody = params;
+                    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+                } else if (body !== '') {
+                    headers['Content-Type'] = contentType;
+                    fetchBody = body;
+                }
+            }
 
             const finalUrl = url.toString();
             const fetchUrl = `https://proxy.scalar.com?scalar_url=${encodeURIComponent(finalUrl)}`;
@@ -253,7 +330,7 @@ export function usePlayground({ method, path, parameters, security, requestBody 
             const response = await fetch(fetchUrl, {
                 method,
                 headers,
-                body: hasBody ? body : undefined,
+                body: fetchBody,
                 credentials: needCookies ? 'include' : 'same-origin',
             });
             const duration = Math.round(performance.now() - start);
@@ -280,13 +357,15 @@ export function usePlayground({ method, path, parameters, security, requestBody 
         } finally {
             setLoading(false);
         }
-    }, [method, path, pathValues, queryValues, headerValues, body, contentType, computedUrl, security, credentials, requestBody, enabledParams]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [method, path, pathValues, queryValues, headerValues, body, contentType, computedUrl, security, credentials, requestBody, enabledParams, formFields, formFiles]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return {
         pathValues, setPathValues,
         queryValues, setQueryValues,
         headerValues, setHeaderValues,
         body, setBody,
+        formFields, setFormFields,
+        formFiles, setFormFiles,
         contentType, setContentType: handleSetContentType,
         contentTypes,
         enabledParams,


### PR DESCRIPTION
## Summary

- **multipart/form-data & application/x-www-form-urlencoded** : le playground affiche maintenant des inputs individuels par champ (schema properties) au lieu d'un textarea JSON brut. Les champs `format: binary` utilisent un file picker. L'envoi construit un `FormData` ou `URLSearchParams` — le header `Content-Type` n'est pas posé manuellement pour multipart (le browser gère le boundary). La commande curl émet `-F` ou `--data`.
- **Example masqué pour les form types** : la section Example dans l'onglet référence est cachée quand le content-type actif est un form type (le schema suffit).
- **Enum pré-sélectionné** : le premier enum est auto-sélectionné dans les selects du playground (sauf si le spec définit une `default`), évitant l'affichage du nom du paramètre comme placeholder.
- **preferredContentType scopé à l'endpoint** : dans Code Examples, `preferredContentType` est validé contre la liste des content types de l'endpoint avant utilisation — une valeur invalide (ou saisie en console) ne pollue plus le header `Content-Type`.

## Test plan

- [ ] Tester un endpoint `multipart/form-data` : vérifier les inputs par champ, le file picker sur les champs `binary`, et la requête envoyée
- [ ] Tester un endpoint `application/x-www-form-urlencoded` : vérifier l'encodage et le header
- [ ] Vérifier qu'un endpoint JSON affiche toujours le textarea
- [ ] Vérifier que les selects enum pré-sélectionnent la première valeur
- [ ] Mettre une valeur invalide dans `skuse_preferred_content_type` (localStorage) et vérifier que le Code Examples fallback sur le premier content type de l'endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)