### PR TITLE
fix: reset content type on endpoint navigation, fix code examples for multipart/form-data

### DIFF
--- a/src/components/openapi/Endpoint/CodeExamples.tsx
+++ b/src/components/openapi/Endpoint/CodeExamples.tsx
@@ -3,6 +3,7 @@ import { HTTPSnippet } from 'httpsnippet-lite';
 import FormattedMarkdown from "@/components/openapi/FormattedMarkdown";
 import { useOpenAPIContext } from '@/hooks/OpenAPIContext';
 import { AuthCredential, SecuritySchemeObject } from '@/types/unified-openapi-types';
+import { isFormType } from '@/hooks/usePlayground';
 import {
     Select,
     SelectContent,
@@ -11,12 +12,15 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 
+type HarParam = { name: string; value?: string; fileName?: string; contentType?: string };
+
 interface CodeExamplesProps {
     method: string;
     path: string;
     requestBody?: string;
     hasRequestBody?: boolean;
     contentTypes?: string[];
+    formParams?: HarParam[];
     security?: Array<Record<string, string[]>>;
     exampleQueryParams?: Record<string, string>;
     exampleHeaderParams?: Array<{ key: string; value: string }>;
@@ -87,7 +91,7 @@ function resolveAuthHeaders(
 }
 
 const CodeExamples: React.FC<CodeExamplesProps> = ({
-    method, path, requestBody, hasRequestBody, contentTypes,
+    method, path, requestBody, hasRequestBody, contentTypes, formParams,
     security, exampleQueryParams, exampleHeaderParams,
 }) => {
     const { computedUrl, credentials, spec, preferredContentType } = useOpenAPIContext();
@@ -121,6 +125,15 @@ const CodeExamples: React.FC<CodeExamplesProps> = ({
                     ...(hasRequestBody ? [{ key: 'Content-Type', value: contentType }] : []),
                 ];
 
+                const postData = (() => {
+                    if (!hasRequestBody) return undefined;
+                    if (isFormType(contentType) && formParams?.length) {
+                        return { mimeType: contentType, params: formParams };
+                    }
+                    if (requestBody) return { mimeType: contentType, text: requestBody };
+                    return undefined;
+                })();
+
                 const harRequest = {
                     method: method.toUpperCase(),
                     url: urlWithQuery,
@@ -128,9 +141,7 @@ const CodeExamples: React.FC<CodeExamplesProps> = ({
                     headers: allHeaders.map(h => ({ name: h.key, value: h.value })),
                     queryString: [] as { name: string; value: string }[],
                     cookies: [] as { name: string; value: string }[],
-                    postData: hasRequestBody && requestBody
-                        ? { mimeType: contentType, text: requestBody }
-                        : undefined,
+                    postData,
                     headersSize: 0,
                     bodySize: 0,
                 };
@@ -148,7 +159,7 @@ const CodeExamples: React.FC<CodeExamplesProps> = ({
         })();
 
         return () => { cancelled = true; };
-    }, [method, path, requestBody, hasRequestBody, selectedLang, computedUrl, credentials, security, spec, preferredContentType, exampleQueryParams, exampleHeaderParams, contentTypes]);
+    }, [method, path, requestBody, hasRequestBody, selectedLang, computedUrl, credentials, security, spec, preferredContentType, exampleQueryParams, exampleHeaderParams, contentTypes, formParams]);
 
     return (
         <div className="space-y-4">

--- a/src/components/openapi/Endpoint/EndpointDetails.tsx
+++ b/src/components/openapi/Endpoint/EndpointDetails.tsx
@@ -16,7 +16,7 @@ import RequestBodyViewer from "@/components/openapi/Endpoint/RequestBodyViewer";
 import CallbackViewer from "@/components/openapi/Endpoint/CallbackViewer";
 import PlaygroundForm from './PlaygroundForm';
 import PlaygroundResponse from './PlaygroundResponse';
-import { usePlayground } from '@/hooks/usePlayground';
+import { usePlayground, isFormType } from '@/hooks/usePlayground';
 import { useOpenAPIContext } from '@/hooks/OpenAPIContext';
 
 interface EndpointContentProps {
@@ -96,10 +96,26 @@ const EndpointContent: React.FC<EndpointContentProps> = ({ operation }) => {
 
     const exampleBody = useMemo(() => {
         if (!requestBody) return '';
-        const contentType = Object.keys(requestBody.content)[0];
+        const contentType = Object.keys(requestBody.content)[0] ?? '';
+        if (isFormType(contentType)) return '';
         const schema = contentType ? requestBody.content[contentType]?.schema : undefined;
         if (!schema) return '';
         return JSON.stringify(generateExample(schema as SchemaObject), null, 2);
+    }, [requestBody]);
+
+    const exampleFormParams = useMemo(() => {
+        if (!requestBody) return undefined;
+        const contentType = Object.keys(requestBody.content)[0] ?? '';
+        if (!isFormType(contentType)) return undefined;
+        const schema = requestBody.content[contentType]?.schema as SchemaObject | undefined;
+        if (!schema?.properties) return undefined;
+        return Object.entries(schema.properties).map(([name, prop]) => {
+            if (prop.format === 'binary') {
+                return { name, fileName: `${name}.bin`, contentType: 'application/octet-stream' };
+            }
+            const val = generateExample(prop as SchemaObject);
+            return { name, value: val !== null && val !== undefined ? String(val) : '' };
+        });
     }, [requestBody]);
 
     const examplePath = useMemo(() => {
@@ -324,6 +340,7 @@ const EndpointContent: React.FC<EndpointContentProps> = ({ operation }) => {
                                 requestBody={exampleBody}
                                 hasRequestBody={!!requestBody}
                                 contentTypes={requestBody ? Object.keys(requestBody.content) : undefined}
+                                formParams={exampleFormParams}
                                 security={operation.security}
                                 exampleQueryParams={exampleQueryParams}
                                 exampleHeaderParams={exampleHeaderParams}

--- a/src/hooks/usePlayground.ts
+++ b/src/hooks/usePlayground.ts
@@ -126,12 +126,16 @@ export function usePlayground({ method, path, parameters, security, requestBody 
     const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
     useEffect(() => {
+        const newCt = (preferredContentType && contentTypes.includes(preferredContentType))
+            ? preferredContentType
+            : (contentTypes[0] ?? 'application/json');
+        setContentType(newCt);
         setPathValues(Object.fromEntries(parameters.filter(p => p.in === 'path').map(p => [p.name, getDefaultParamValue(p)])));
         setQueryValues(Object.fromEntries(parameters.filter(p => p.in === 'query').map(p => [p.name, getDefaultParamValue(p)])));
         setHeaderValues(Object.fromEntries(parameters.filter(p => p.in === 'header').map(p => [p.name, getDefaultParamValue(p)])));
         setEnabledParams(Object.fromEntries(parameters.map(p => [`${p.in}:${p.name}`, true])));
-        setBody(getDefaultBody(contentType));
-        setFormFields(getFormFields(contentType, requestBody));
+        setBody(getDefaultBody(newCt));
+        setFormFields(getFormFields(newCt, requestBody));
         setFormFiles({});
         setResult(null);
         setError(null);


### PR DESCRIPTION
## Summary

- **Content type reset on endpoint navigation**: when switching endpoints, `contentType` was not reset — it kept the value from the previous endpoint. This caused going from a multipart endpoint to a JSON endpoint to display "No schema properties defined" with an empty content type select (and vice-versa). Fix: content type is now recomputed from the new endpoint's available content types in the `[path, method]` effect.
- **Code examples for multipart/form-data**: snippets (curl, Python, JS…) were generating a JSON body for `multipart/form-data` and `application/x-www-form-urlencoded` endpoints. Fix: `httpsnippet-lite` now receives `postData.params` (array of `{name, value/fileName}`) instead of `postData.text`, producing correct snippets (`--form`, `files=`, etc.).

## Test plan

- [x] Navigate from a multipart endpoint to a JSON endpoint: verify the JSON textarea is shown with the correct content type selected
- [x] Navigate from a JSON endpoint to a multipart endpoint: verify the FormFieldsEditor is shown
- [x] On a multipart endpoint, verify the curl snippet shows `--form` instead of a JSON body
- [x] Same check for other languages (Python, JS fetch, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)