### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skuse-ui",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A modern, beautiful OpenAPI documentation viewer — fully compatible with OpenAPI 3.0 and 3.1",
   "keywords": ["openapi", "swagger", "api", "documentation", "react", "ui"],
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump `package.json` version `0.1.6` → `0.1.7`
- Built with `npm run build` before bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)