### PR TITLE
fix: pass openApiUrl via context instead of route closure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skuse-ui",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A modern, beautiful OpenAPI documentation viewer — fully compatible with OpenAPI 3.0 and 3.1",
   "keywords": ["openapi", "swagger", "api", "documentation", "react", "ui"],
   "license": "MIT",

--- a/src/SkuseDocumentation.tsx
+++ b/src/SkuseDocumentation.tsx
@@ -7,7 +7,7 @@ import LayoutSkeleton from '@/components/Skeletons/LayoutSkeleton';
 import { Menu, AlertCircle, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { OpenAPIProvider } from '@/hooks/OpenAPIContext';
+import { OpenAPIProvider, useOpenAPIContext } from '@/hooks/OpenAPIContext';
 import { ThemeProvider } from '@/components/theme-provider';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { Toaster } from '@/components/ui/sonner';
@@ -22,7 +22,8 @@ export interface SkuseDocumentationProps {
 }
 
 // Internal layout — rendered inside the router context
-export const DocumentationShell: React.FC<{ openApiUrl: string }> = ({ openApiUrl }) => {
+export const DocumentationShell: React.FC = () => {
+    const { openApiUrl } = useOpenAPIContext();
     const { spec, error, loading, retry } = useSpec({ openApiUrl });
     const location = useLocation();
     const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -104,12 +105,12 @@ export const SkuseDocumentation: React.FC<SkuseDocumentationProps> = ({
     theme = 'system',
     routerMode = 'browser',
 }) => {
-    const router = useMemo(() => createAppRouter(openApiUrl, routerMode), [openApiUrl, routerMode]);
+    const router = useMemo(() => createAppRouter(routerMode), [routerMode]);
 
     return (
         <ThemeProvider defaultTheme={theme} storageKey="skuse-ui-theme">
             <TooltipProvider delayDuration={300}>
-                <OpenAPIProvider>
+                <OpenAPIProvider openApiUrl={openApiUrl}>
                     <RouterProvider router={router} />
                     <Toaster richColors closeButton position="bottom-right" />
                 </OpenAPIProvider>

--- a/src/hooks/OpenAPIContext.tsx
+++ b/src/hooks/OpenAPIContext.tsx
@@ -23,6 +23,7 @@ const defaultSpec: UnifiedOpenAPI = {
 };
 
 interface OpenAPIContextType {
+    openApiUrl: string;
     spec: UnifiedOpenAPI;
     setSpec: (spec: UnifiedOpenAPI) => void;
     computedUrl: string;
@@ -41,6 +42,7 @@ interface OpenAPIContextType {
 }
 
 const OpenAPIContext = createContext<OpenAPIContextType>({
+    openApiUrl: '',
     spec: defaultSpec,
     setSpec: () => {},
     computedUrl: '',
@@ -58,7 +60,7 @@ const OpenAPIContext = createContext<OpenAPIContextType>({
     setPreferredContentType: () => {},
 });
 
-export const OpenAPIProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+export const OpenAPIProvider: React.FC<{ children: ReactNode; openApiUrl: string }> = ({ children, openApiUrl }) => {
     const [spec, setSpec] = useState<UnifiedOpenAPI>(defaultSpec);
     const [computedUrl, setComputedUrl] = useState<string>('');
     const [serverVariables, setServerVariables] = useState<Record<string, string>>({});
@@ -88,6 +90,7 @@ export const OpenAPIProvider: React.FC<{ children: ReactNode }> = ({ children })
     return (
         <OpenAPIContext.Provider
             value={{
+                openApiUrl,
                 spec,
                 setSpec,
                 computedUrl,

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -10,9 +10,9 @@ import EndpointDetails from "@/components/openapi/Endpoint/EndpointDetails";
 import Models from "@/components/openapi/Models";
 import WebhookDetails from "@/components/openapi/WebhookDetails";
 
-export function createAppRouter(openApiUrl: string, routerMode: 'browser' | 'hash' = 'browser') {
+export function createAppRouter(routerMode: 'browser' | 'hash' = 'browser') {
     const rootRoute = new RootRoute({
-        component: () => <DocumentationShell openApiUrl={openApiUrl} />
+        component: DocumentationShell,
     });
 
     const indexRoute = new Route({


### PR DESCRIPTION
…hardcoded URL in IIFE bundle

In TanStack Router v1, routes are designed as static module-level singletons. Creating them inside a function (useMemo) caused the openApiUrl closure to be evaluated at Rollup bundle time, producing a hardcoded localhost URL in the published IIFE. openApiUrl now flows through OpenAPIContext so the route component has no closure dependency on it.

Bumps to 0.1.8.